### PR TITLE
Fix how current branch is determined

### DIFF
--- a/src/LocalCoverage.jl
+++ b/src/LocalCoverage.jl
@@ -62,7 +62,7 @@ function generate_coverage(pkg; genhtml = true)
         tracefile = "$(COVDIR)/lcov.info"
         Coverage.LCOV.writefile(tracefile, coverage)
         if genhtml
-            branch = strip(read(`git branch`, String), [' ', '*', '\n'])
+            branch = strip(read(`git rev-parse --abbrev-ref HEAD`, String))
             title = "on branch $(branch)"
             run(`genhtml -t $(title) -o $(COVDIR) $(tracefile)`)
         end


### PR DESCRIPTION
git branch doesn't just return the current branch; it returns a list of all branches that are available locally. This results in a malformed title (screenshot below).

![Screen Shot 2019-06-07 at 5 36 18 PM](https://user-images.githubusercontent.com/773453/59139869-38cca900-894b-11e9-9ef0-b6d032cf6115.png)